### PR TITLE
Posiciona a substituição dos duplos primariamente

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,7 @@ namespace Cebolinha
             
             
             string troca = Console.ReadLine(); 
-            Console.WriteLine(troca.Replace("r","l").Replace("R","L").Replace("RR","LL").Replace("rr","ll"));
+            Console.WriteLine(troca.Replace("RR","LL").Replace("rr","ll").Replace("r","l").Replace("R","L"));
             
 
 


### PR DESCRIPTION
Caso você substitua todo os r e R, não sobrará substituição para rr e RR.